### PR TITLE
Fill globals data, when a savegame is loaded

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -100,6 +100,7 @@ end
 
 script.on_init(onLoad)
 script.on_configuration_changed(onLoad)
+script.on_load(onLoad)
 
 script.on_event(defines.events.on_built_entity, onPlaceEntity)
 script.on_event(defines.events.on_robot_built_entity, onPlaceEntity)


### PR DESCRIPTION
Hello,

First of all thanks for this nice mod, this is what I needed for my dashboard design, where a lamp is lit, when a resource is low in the logistic network.

The combinators stopped refreshing their data after the game is loaded. This one line fixed the issue for me.

Thanks,
Peter
